### PR TITLE
feat: create general questions components

### DIFF
--- a/vale-sem-fome/src/components/Questions/GeneralQuestions/AcceptanceTerm/index.js
+++ b/vale-sem-fome/src/components/Questions/GeneralQuestions/AcceptanceTerm/index.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Input } from './../../../index';
+
+function AcceptanceTerm(props) {
+    return (
+        <div className="form-group" id="agreement">
+        <div className="inputs-group">
+            <div className="link">
+                <a href="#question1">Revisar minhas Repostas</a>
+            </div>
+            <section>
+                <h3>TERMO DE ACEITE</h3>
+                <p>
+                    Autorizo receber mensagens com informações e questões sobre
+                    <strong> MOVIMENTO COVID19 SJC SEM FOME</strong> e que meus dados sejam armazenados
+                    para fins estatísticos nos termos da Lei Geral de Proteção de Dados. *
+                </p>
+            </section>
+            {props.errors.termsAgreements && <span className="error-message">Campo obrigatório...</span>}
+            <div className="all-options">
+                <div className="option">
+                    <Input
+                        type="radio"
+                        name="termsAgreements"
+                        id="agree"
+                        value="Aceito"
+                        ref={props.register({ required: true })} />
+                    <label htmlFor="agree"> Aceito</label>
+                </div>
+                <div className="option">
+                    <Input
+                        type="radio"
+                        name="termsAgreements"
+                        id="not-agree"
+                        value="Não aceito"
+                        ref={props.register({ required: true })} />
+                    <label htmlFor="not-agree"> Não Aceito</label>
+                </div>
+            </div>
+            <div className="form-buttons" id="send-answer">
+                <Input name="button" type="submit" value="Enviar" />
+            </div>
+        </div>
+    </div>
+    )
+}
+
+export default AcceptanceTerm;

--- a/vale-sem-fome/src/components/Questions/GeneralQuestions/BirthDay/index.js
+++ b/vale-sem-fome/src/components/Questions/GeneralQuestions/BirthDay/index.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Input } from './../../../index';
+
+function BirthDay(props) {
+    return (
+        <div className="form-group">
+        <div className="inputs-group">
+            <label htmlFor="birthday">
+                Data de Nascimento: *
+            </label>
+            {props.errors.birthday && <span className="error-message">Você não preencheu com a sua data de nascimento...</span>}
+            <Input
+                type="date"
+                name="birthday"
+                id="birthday"
+                ref={props.register({ required: true, maxLength: 10 })} />
+        </div>
+    </div>
+    )
+}
+
+export default BirthDay;

--- a/vale-sem-fome/src/components/Questions/GeneralQuestions/Document/index.js
+++ b/vale-sem-fome/src/components/Questions/GeneralQuestions/Document/index.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { InputMask } from './../../../index';
+
+function Document(props) {
+    return (
+        <div className="form-group">
+            <div className="inputs-group">
+                <label htmlFor="cpf">
+                    Qual é o seu CPF? (11 dígitos) *
+                </label>
+                {props.errors.document && <span className="error-message">Campo Obrigatório. Digitar seu CPF:</span>}
+                <InputMask
+                    type="text"
+                    name="document"
+                    id="cpf"
+                    placeholder="000.111.222-33"
+                    mask="999.999.999-99"
+                    inputRef={props.register({ required: true, minLength: 11, maxLength: 14 })} 
+                />
+            </div>
+        </div>
+    )
+}
+
+export default Document;

--- a/vale-sem-fome/src/components/Questions/GeneralQuestions/Email/index.js
+++ b/vale-sem-fome/src/components/Questions/GeneralQuestions/Email/index.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Input } from './../../../index';
+
+function Email(props) {
+    return (
+        <div className="form-group">
+        <div className="inputs-group">
+            {props.errors.email && <span className="error-message">Você precisa digitar um e-mail válido...</span>}
+            <label htmlFor="email">
+                Qual é o seu e-mail?
+            </label>
+            <Input
+                type="email"
+                name="email"
+                id="email"
+                placeholder="Responda aqui..."
+                ref={props.register()} />
+            <label htmlFor="email" className="optional-field">Esse campo é opcional.</label>
+        </div>
+    </div>
+    )
+}
+
+export default Email;

--- a/vale-sem-fome/src/components/Questions/GeneralQuestions/FullName/index.js
+++ b/vale-sem-fome/src/components/Questions/GeneralQuestions/FullName/index.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { 
+    Input
+} from '../../../index';
+
+function FullName(props) {
+    return (
+        <div className="form-group">
+            <div className="inputs-group">
+                <label htmlFor="full-name">
+                    Qual seu nome completo? *
+                </label>
+                {props.errors.fullName && <span className="error-message">É necessário digitar seu nome completo!</span>}
+                <Input
+                    name="fullName"
+                    type="text"
+                    id="full-name"
+                    placeholder="Responda aqui..."
+                    ref={props.register({ required: true })} 
+                />
+            </div>
+        </div>
+    );
+}
+
+export default FullName;

--- a/vale-sem-fome/src/components/Questions/GeneralQuestions/HomeAddress/index.js
+++ b/vale-sem-fome/src/components/Questions/GeneralQuestions/HomeAddress/index.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import { Input, InputMask } from './../../../index';
+
+function HomeAddress(props) {
+    return (
+        <div className="form-group">
+        <div className="inputs-group">
+            <label htmlFor="address">
+                Qual é o seu endereço São José dos Campos? *
+            </label>
+            <div className="input-field">
+                {props.errorsMock.cep && <span className="error-message">Digite um CEP válido...</span>}
+                <label htmlFor="cep">CEP*:</label>
+                <InputMask
+                    type="text"
+                    name="cep"
+                    id="cep"
+                    placeholder="12000-000"
+                    mask="99999-999"
+                    value={props.cep}
+                    onChange={props.getCEP} />
+            </div>
+            <div className="input-field">
+                {props.errorsMock.street && <span className="error-message">Campo obrigatório...</span>}
+                <label htmlFor="street">Rua*:</label>
+                <Input
+                    type="text"
+                    name="street"
+                    id="street"
+                    placeholder="Avenida das Flores"
+                    value={props.street}
+                    onChange={(event) => props.setStreet(event.target.value)} />
+            </div>
+            {props.errors.number && <span className="error-message">Campo obrigatório...</span>}
+            <div className="input-field">
+                <label htmlFor="house-number">Nº*:</label>
+                <Input
+                    type="text"
+                    name="number"
+                    id="house-number"
+                    placeholder="200"
+                    ref={props.register({ required: true })} />
+
+            </div>
+            <div className="input-field">
+                {props.errorsMock.neighborhood && <span className="error-message">Campo obrigatório...</span>}
+                <label htmlFor="neighborhood">Bairro*:</label>
+                <Input
+                    type="text"
+                    name="neighborhood"
+                    id="neighborhood"
+                    placeholder="Campo dos Elíseos"
+                    value={props.neighborhood}
+                    onChange={(event) => props.setNeighborhood(event.target.value)} />
+            </div>
+            <div className="input-field">
+                <label htmlFor="reference-point">Ponto de Referência:</label>
+                <Input
+                    type="text"
+                    name="referencePoint"
+                    id="reference-point"
+                    placeholder="Na esquina do campo de futebol."
+                    ref={props.register} />
+            </div>
+
+            <div className="input-field">
+                <label htmlFor="reference-point">Complemento:</label>
+                <Input
+                    type="text"
+                    name="complement"
+                    id="complement"
+                    placeholder="Responda aqui..."
+                    value={props.complement}
+                    onChange={(event) => props.setComplement(event.target.value)} />
+            </div>
+        </div>
+    </div>
+    )
+}
+
+export default HomeAddress;

--- a/vale-sem-fome/src/components/Questions/GeneralQuestions/PhoneNumber/index.js
+++ b/vale-sem-fome/src/components/Questions/GeneralQuestions/PhoneNumber/index.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { InputMask } from './../../../index';
+
+function PhoneNumber(props) {
+    return (
+        <div className="form-group">
+        <div className="inputs-group">
+            <label htmlFor="whatsapp">
+                Qual é o seu telefone de contato (WhatsApp)? *
+            </label>
+            {props.errors.phone && <span className="error-message">Digite um número de telefone válido...</span>}
+            <InputMask
+                type="text"
+                name="phone"
+                id="whatsapp"
+                mask="(99) 99999-9999"
+                placeholder="(12) 99111-1111"
+                inputRef={props.register({ required: true, minLength: 14, maxLength: 15 })} />
+        </div>
+    </div>
+    )
+}
+
+export default PhoneNumber;

--- a/vale-sem-fome/src/components/Questions/SpecificQuestions/Recipients/GeneralsQuestions/CurrentFinancialsStatus/index.js
+++ b/vale-sem-fome/src/components/Questions/SpecificQuestions/Recipients/GeneralsQuestions/CurrentFinancialsStatus/index.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import { Input } from './../../../../../index';
+
+function CurrentFinancialStatus(props) {
+    return (
+        <div className="form-group">
+        <div className="inputs-group">
+            <label>
+                Como você considera sua situação neste momento? *
+            </label>
+            {props.errors.situationMoment && <span className="error-message">Campo Obrigatório...</span>}
+            <div className="all-options">
+                <div className="option">
+                    <Input
+                        type="radio"
+                        name="situationMoment"
+                        id="ext-serious"
+                        value="Extremamente Séria"
+                        ref={props.register({ required: true })} />
+                    <label htmlFor="ext-serious"> Extremamente Séria - Não tenho nenhuma renda nem nada para comer</label>
+                </div>
+                <div className="option">
+                    <Input
+                        type="radio"
+                        name="situationMoment"
+                        id="much-serious"
+                        value="Muito Séria"
+                        ref={props.register({ required: true })} />
+                    <label htmlFor="much-serious"> Muito Séria - Tenho pouquíssima renda e muito pouco para comer</label>
+                </div>
+                <div className="option">
+                    <Input
+                        type="radio"
+                        name="situationMoment"
+                        id="serious"
+                        value="Séria"
+                        ref={props.register({ required: true })} />
+                    <label htmlFor="serious"> Séria - Tenho alguma comida, mas não irá durar muito.</label>
+                </div>
+                <div className="option">
+                    <Input
+                        type="radio"
+                        name="situationMoment"
+                        id="risk"
+                        value="Em Risco"
+                        ref={props.register({ required: true })} />
+                    <label htmlFor="risk"> Em Risco - Só tenho o mínimo.</label>
+                </div>
+                <div className="option">
+                    <div className="other-aws">
+                        <Input
+                            type="radio"
+                            name="situationMoment"
+                            id="other-aws"
+                            value="Outro"
+                            ref={props.register({ required: true })} />
+                        <label htmlFor="other-aws"> Outro</label>
+                        <Input
+                            type="text"
+                            name="situationMomentOther"
+                            id="other-aws"
+                            placeholder="Responda aqui..."
+                            ref={props.register}
+                        />
+                    </div>
+                </div>
+            </div>
+        </div>
+        </div>
+    )
+}
+
+export default CurrentFinancialStatus;

--- a/vale-sem-fome/src/components/Questions/SpecificQuestions/Recipients/GeneralsQuestions/PreviousRegister/index.js
+++ b/vale-sem-fome/src/components/Questions/SpecificQuestions/Recipients/GeneralsQuestions/PreviousRegister/index.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Input } from './../../../../../index';
+
+function PreviousRegister(props) {
+    return (
+        <div className="form-group" id="question10">
+        <div className="inputs-group">
+            <label>
+                Por último, você (sua família) já possuem cadastro único? *
+            </label>
+            {props.errors.haveRegistry && <span className="error-message">Campo obrigatório...</span>}
+            <span className="optional-field">A entrega da doação não depende de nenhum cadastro prévio.</span>
+            <div className="all-options">
+                <div className="option">
+                    <Input
+                        type="radio"
+                        name="haveRegistry"
+                        id="yes-aws"
+                        value="Sim"
+                        ref={props.register({ required: true })} />
+                    <label htmlFor="yes-aws"> Sim</label>
+                </div>
+                <div className="option">
+                    <Input
+                        type="radio"
+                        name="haveRegistry"
+                        id="not-aws"
+                        value="Não"
+                        ref={props.register({ required: true })} />
+                    <label htmlFor="not-aws"> Não.</label>
+                </div>
+                <div className="option">
+                    <Input
+                        type="radio"
+                        name="haveRegistry"
+                        id="not-know-aws"
+                        value="Não sei"
+                        ref={props.register({ required: true })} />
+                    <label htmlFor="not-know-aws"> Não sei.</label>
+                </div>
+            </div>
+        </div>
+        </div>
+    )
+}
+
+export default PreviousRegister;

--- a/vale-sem-fome/src/components/Questions/SpecificQuestions/Recipients/GeneralsQuestions/ResidentsQuantity/index.js
+++ b/vale-sem-fome/src/components/Questions/SpecificQuestions/Recipients/GeneralsQuestions/ResidentsQuantity/index.js
@@ -1,0 +1,118 @@
+import React from 'react';
+import { Input } from './../../../../../index';
+
+function ResidentsQuantity(props) {
+    return (
+        <div className="form-group">
+        <div className="inputs-group">
+            <label>
+                <span className="question-number">6.</span> Quantas pessoas vivem na sua casa? *
+            </label>
+            {props.errors.residents && <span className="error-message">Campo obrigatório...</span>}
+            <div className="all-options">
+                <div className="option">
+                    <Input
+                        type="radio"
+                        name="residents"
+                        id="opt1"
+                        value="1"
+                        ref={props.register({ required: true })} />
+                    <label htmlFor="opt1"> 1</label>
+                </div>
+                <div className="option">
+                    <Input
+                        type="radio"
+                        name="residents"
+                        id="opt2"
+                        value="2"
+                        ref={props.register({ required: true })} />
+                    <label htmlFor="opt2"> 2</label>
+                </div>
+                <div className="option">
+                    <Input
+                        type="radio"
+                        name="residents"
+                        id="opt3"
+                        value="3"
+                        ref={props.register({ required: true })} />
+                    <label htmlFor="opt3"> 3</label>
+                </div>
+                <div className="option">
+                    <Input
+                        type="radio"
+                        name="residents"
+                        id="opt4"
+                        value="4"
+                        ref={props.register({ required: true })} />
+                    <label htmlFor="opt4"> 4</label>
+                </div>
+                <div className="option">
+                    <Input
+                        type="radio"
+                        name="residents"
+                        id="opt5"
+                        value="5"
+                        ref={props.register({ required: true })} />
+                    <label htmlFor="opt5"> 5</label>
+                </div>
+                <div className="option">
+                    <Input
+                        type="radio"
+                        name="residents"
+                        id="opt6"
+                        value="6"
+                        ref={props.register({ required: true })} />
+                    <label htmlFor="opt6"> 6</label>
+                </div>
+                <div className="option">
+                    <Input
+                        type="radio"
+                        name="residents"
+                        id="opt7"
+                        value="7"
+                        ref={props.register({ required: true })} />
+                    <label htmlFor="opt7"> 7</label>
+                </div>
+                <div className="option">
+                    <Input
+                        type="radio"
+                        name="residents"
+                        id="opt8"
+                        value="8"
+                        ref={props.register({ required: true })} />
+                    <label htmlFor="opt8"> 8</label>
+                </div>
+                <div className="option">
+                    <Input
+                        type="radio"
+                        name="residents"
+                        id="opt9"
+                        value="9"
+                        ref={props.register({ required: true })} />
+                    <label htmlFor="opt9"> 9</label>
+                </div>
+                <div className="option">
+                    <Input
+                        type="radio"
+                        name="residents"
+                        id="opt10"
+                        value="10"
+                        ref={props.register({ required: true })} />
+                    <label htmlFor="opt10"> 10</label>
+                </div>
+                <div className="option">
+                    <Input
+                        type="radio"
+                        name="residents"
+                        id="opt-10more"
+                        value="+10"
+                        ref={props.register({ required: true })} />
+                    <label htmlFor="opt-10more"> <strong>+</strong>10</label>
+                </div>
+            </div>
+        </div>
+    </div>
+    )
+}
+
+export default ResidentsQuantity;

--- a/vale-sem-fome/src/components/Questions/SpecificQuestions/Recipients/SJC/RegionCity/index.js
+++ b/vale-sem-fome/src/components/Questions/SpecificQuestions/Recipients/SJC/RegionCity/index.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import { Input } from './../../../../../index';
+
+function RegionCity(props){
+    return (
+        <div className="form-group">
+            <div className="inputs-group">
+                <label>
+                    Qual região da cidade fica sua residência? *
+                </label>
+                {props.errors.region && <span className="error-message">Campo obrigatório...</span>}
+                <div className="all-options">
+                    <div className="option">
+                        <Input
+                            type="radio"
+                            name="region"
+                            id="opt-south"
+                            value="Sul"
+                            ref={props.register({ required: true })} />
+                        <label htmlFor="opt-south"> Sul</label>
+                    </div>
+                    <div className="option">
+                        <Input
+                            type="radio"
+                            name="region"
+                            id="opt-north"
+                            value="Norte"
+                            ref={props.register({ required: true })} />
+                        <label htmlFor="opt-north"> Norte</label>
+                    </div>
+                    <div className="option">
+                        <Input
+                            type="radio"
+                            name="region"
+                            id="opt-center"
+                            value="Centro"
+                            ref={props.register({ required: true })} />
+                        <label htmlFor="opt-center"> Centro</label>
+                    </div>
+                    <div className="option">
+                        <Input
+                            type="radio"
+                            name="region"
+                            id="opt-west"
+                            value="Oeste"
+                            ref={props.register({ required: true })} />
+                        <label htmlFor="opt-west"> Oeste</label>
+                    </div>
+                    <div className="option">
+                        <Input
+                            type="radio"
+                            name="region"
+                            id="opt-east"
+                            value="Leste"
+                            ref={props.register({ required: true })} />
+                        <label htmlFor="opt-east"> Leste</label>
+                    </div>
+                    <div className="option">
+                        <Input
+                            type="radio"
+                            name="region"
+                            id="opt-sfx"
+                            value="Distrito SFX"
+                            ref={props.register({ required: true })} />
+                        <label htmlFor="opt-sfx"> Distrito SFX</label>
+                    </div>
+                    <div className="option">
+                        <Input
+                            type="radio"
+                            name="region"
+                            id="opt-edm"
+                            value="Distrito Eugênio de Melo"
+                            ref={props.register({ required: true })} />
+                        <label htmlFor="opt-edm"> Distrito Eugênio de Melo</label>
+                    </div>
+                </div>
+                </div>
+            </div>
+    )
+}
+
+export default RegionCity;

--- a/vale-sem-fome/src/components/Questions/SpecificQuestions/Volunteers/AvaiableDays/index.js
+++ b/vale-sem-fome/src/components/Questions/SpecificQuestions/Volunteers/AvaiableDays/index.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Input } from './../../../../index';
+
+function AvaiableDays(props) {
+    return (
+        <div className="form-group">
+            <div className="inputs-group">
+                <label>
+                    Quais dias na semana você poderia ajudar? (selecione quantos quiser) *
+                </label>
+                <div className="all-options">
+                    <div className="option">
+                        <Input
+                            type="checkbox"
+                            name="monday"
+                            id="monday"
+                            value="Segunda"
+                            ref={props.register()} />
+                        <label htmlFor="monday"> Segunda</label>
+                    </div>
+                    <div className="option">
+                        <Input
+                            type="checkbox"
+                            name="tuesday"
+                            id="tuesday"
+                            value="Terça"
+                            ref={props.register()} />
+                        <label htmlFor="tuesday"> Terça</label>
+                    </div>
+                    <div className="option">
+                        <Input
+                            type="checkbox"
+                            name="wednesday"
+                            id="wednesday"
+                            value="Quarta"
+                            ref={props.register()} />
+                        <label htmlFor="wednesday"> Quarta</label>
+                    </div>
+                    <div className="option">
+                        <Input
+                            type="checkbox"
+                            name="thursday"
+                            id="thursday"
+                            value="Quinta"
+                            ref={props.register()} />
+                        <label htmlFor="thursday"> Quinta</label>
+                    </div>
+                    <div className="option">
+                        <Input
+                            type="checkbox"
+                            name="friday"
+                            id="friday"
+                            value="Sexta"
+                            ref={props.register()} />
+                        <label htmlFor="friday"> Sexta</label>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default AvaiableDays;

--- a/vale-sem-fome/src/components/Questions/SpecificQuestions/Volunteers/AvaiableHours/index.js
+++ b/vale-sem-fome/src/components/Questions/SpecificQuestions/Volunteers/AvaiableHours/index.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Input } from './../../../../index';
+
+function AvaiableHours(props) {
+    return (
+    <div className="form-group" id="question10">
+        <div className="inputs-group">
+            <label>
+                Qual período do dia você poderia ajudar? *
+            </label>
+            {props.errors.scheduleTime && <span className="error-message">Campo obrigatorio...</span>}
+            <div className="all-options">
+                <div className="option">
+                    <Input
+                        type="radio"
+                        name="scheduleTime"
+                        id="op1-scheduleTime"
+                        value="Manhã (8h às 12h)"
+                        ref={props.register({ required: true })} />
+                    <label htmlFor="op1-scheduleTime"> Manhã (8h às 12h)</label>
+                </div>
+                <div className="option">
+                    <Input
+                        type="radio"
+                        name="scheduleTime"
+                        id="op2-scheduleTime"
+                        value="Tarde (13h às 18h)"
+                        ref={props.register({ required: true })} />
+                    <label htmlFor="op2-scheduleTime"> Tarde (13h às 18h)</label>
+                </div>
+                <div className="option">
+                    <Input
+                        type="radio"
+                        name="scheduleTime"
+                        id="op3-scheduleTime"
+                        value="Manhã e Tarde"
+                        ref={props.register({ required: true })} />
+                    <label htmlFor="op3-scheduleTime"> Manhã e Tarde</label>
+                </div>
+                <div className="option">
+                    <Input
+                        type="radio"
+                        name="scheduleTime"
+                        id="op4-scheduleTime"
+                        value="Outro"
+                        ref={props.register({ required: true })} />
+                    <label htmlFor="op4-scheduleTime"> Outro</label>
+                </div>
+            </div>
+        </div>
+    </div>
+    );
+}
+
+export default AvaiableHours;

--- a/vale-sem-fome/src/components/Questions/SpecificQuestions/Volunteers/PreviousVolunteersRegister/index.js
+++ b/vale-sem-fome/src/components/Questions/SpecificQuestions/Volunteers/PreviousVolunteersRegister/index.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Input } from './../../../../index';
+
+function PreviousVolunteersRegister(props) {
+    return (
+        <div className="form-group">
+            <div className="inputs-group">
+                <label>
+                    Você já havia se cadastrado antes como voluntários do Movimento Covid19 SJC SEM FOME? *
+                </label>
+                {props.errors.isRegister && <span className="error-message">Campo Obrigatório...</span>}
+                <div className="all-options">
+                    <div className="option">
+                        <Input
+                            type="radio"
+                            name="isRegister"
+                            id="op1-isRegister"
+                            value="Sim"
+                            ref={props.register({ required: true })} />
+                        <label htmlFor="op1-isRegister"> Sim.</label>
+                    </div>
+                    <div className="option">
+                        <Input
+                            type="radio"
+                            name="isRegister"
+                            id="op2-isRegister"
+                            value="Não, esta é a primeira vez"
+                            ref={props.register({ required: true })} />
+                        <label htmlFor="op2-isRegister"> Não, esta é a primeira vez.</label>
+                    </div>
+                    <div className="option">
+                        <Input
+                            type="radio"
+                            name="isRegister"
+                            id="op3-isRegister"
+                            value="Não me lembro"
+                            ref={props.register({ required: true })} />
+                        <label htmlFor="op3-isRegister"> Não me lembro.</label>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default PreviousVolunteersRegister;

--- a/vale-sem-fome/src/components/Questions/SpecificQuestions/Volunteers/WorkFront/index.js
+++ b/vale-sem-fome/src/components/Questions/SpecificQuestions/Volunteers/WorkFront/index.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Input } from './../../../../index';
+
+function WorkFront(props) {
+    return (
+    <div className="form-group">
+        <div className="inputs-group">
+            <label>
+                Qual frente você pode ajudar? *
+            </label>
+            {props.errors.jobArea && <span className="error-message">Campo obrigatório...</span>}
+            <div className="all-options">
+                <div className="option">
+                    <Input
+                        type="radio"
+                        name="jobArea"
+                        id="opt1"
+                        value="Montagem de Kits de Alimentos"
+                        ref={props.register({ required: true })} />
+                    <label htmlFor="opt1"> Montagem de Kits de Alimentos</label>
+                </div>
+                <div className="option">
+                    <Input
+                        type="radio"
+                        name="jobArea"
+                        id="opt2"
+                        value="Entrega Porta a Porta (necessário ter carro)"
+                        ref={props.register({ required: true })} />
+                    <label htmlFor="opt2"> Entrega Porta a Porta (necessário ter carro)</label>
+                </div>
+                <div className="option">
+                    <Input
+                        type="radio"
+                        name="jobArea"
+                        id="opt3"
+                        value="Ambos"
+                        ref={props.register({ required: true })} />
+                    <label htmlFor="opt3"> Ambos</label>
+                </div>
+            </div>
+        </div>
+    </div>
+    );
+}
+
+export default WorkFront;

--- a/vale-sem-fome/src/components/index.js
+++ b/vale-sem-fome/src/components/index.js
@@ -8,7 +8,7 @@ export { default as Images} from './Images'
 export { default as HeaderVolunteer } from './FormVolunteers/Header'
 
 /**
- * Questions
+ * Generics Questions
  */
 
 export { default as FullName } from './Questions/GeneralQuestions/FullName'
@@ -18,3 +18,22 @@ export { default as BirthDay } from './Questions/GeneralQuestions/BirthDay'
 export { default as PhoneNumber } from './Questions/GeneralQuestions/PhoneNumber'
 export { default as HomeAddress } from './Questions/GeneralQuestions/HomeAddress'
 export { default as AcceptanceTerm } from './Questions/GeneralQuestions/AcceptanceTerm'
+
+
+/**
+ * Specific Questions: Recipients
+ */
+
+export { default as ResidentsQuantity} from './Questions/SpecificQuestions/Recipients/GeneralsQuestions/ResidentsQuantity'
+export { default as RegionCity } from './Questions/SpecificQuestions/Recipients/SJC/RegionCity'
+export { default as CurrentFinancialStatus } from './Questions/SpecificQuestions/Recipients/GeneralsQuestions/CurrentFinancialsStatus'
+export { default as PreviousRegister } from './Questions/SpecificQuestions/Recipients/GeneralsQuestions/PreviousRegister'
+
+/**
+ * Specific Questions: Volunteers
+ */
+
+export { default as AvaiableDays } from './Questions/SpecificQuestions/Volunteers/AvaiableDays'
+export { default as AvaiableHours } from './Questions/SpecificQuestions/Volunteers/AvaiableHours'
+export { default as PreviousVolunteersRegister } from './Questions/SpecificQuestions/Volunteers/PreviousVolunteersRegister'
+export { default as WorkFront } from './Questions/SpecificQuestions/Volunteers/WorkFront'

--- a/vale-sem-fome/src/components/index.js
+++ b/vale-sem-fome/src/components/index.js
@@ -6,3 +6,15 @@ export { default as Footer } from './FormRecipients/Footer'
 export { default as InputMask } from './InputMask'
 export { default as Images} from './Images'
 export { default as HeaderVolunteer } from './FormVolunteers/Header'
+
+/**
+ * Questions
+ */
+
+export { default as FullName } from './Questions/GeneralQuestions/FullName'
+export { default as Document } from './Questions/GeneralQuestions/Document'
+export { default as Email } from './Questions/GeneralQuestions/Email'
+export { default as BirthDay } from './Questions/GeneralQuestions/BirthDay'
+export { default as PhoneNumber } from './Questions/GeneralQuestions/PhoneNumber'
+export { default as HomeAddress } from './Questions/GeneralQuestions/HomeAddress'
+export { default as AcceptanceTerm } from './Questions/GeneralQuestions/AcceptanceTerm'

--- a/vale-sem-fome/src/pages/TestNewComponents/index.js
+++ b/vale-sem-fome/src/pages/TestNewComponents/index.js
@@ -6,7 +6,15 @@ import {
     BirthDay,
     PhoneNumber,
     HomeAddress,
-    AcceptanceTerm
+    AcceptanceTerm,
+    RegionCity,
+    CurrentFinancialStatus,
+    PreviousRegister,
+    ResidentsQuantity,
+    AvaiableDays,
+    AvaiableHours,
+    PreviousVolunteersRegister,
+    WorkFront
 } from './../../components';
 import { useForm } from 'react-hook-form';
 import validarCpf from 'validar-cpf'
@@ -91,12 +99,13 @@ function TestNewComponents(props) {
 
     return (
         <div className="container">
+        <h1>Questions Genéricas</h1>
             <form onSubmit={handleSubmit(onSubmit)} className="form" id="form">
-                <FullName register={register} errors={errors}/>
-                <Document register={register} errors={errors}/>
-                <Email register={register} errors={errors}/>
-                <BirthDay register={register} errors={errors}/>
-                <PhoneNumber register={register} errors={errors}/>
+                <FullName register={register} errors={errors} />
+                <Document register={register} errors={errors} />
+                <Email register={register} errors={errors} />
+                <BirthDay register={register} errors={errors} />
+                <PhoneNumber register={register} errors={errors} />
                 <HomeAddress 
                     register={register}
                     errors={errors}
@@ -111,7 +120,21 @@ function TestNewComponents(props) {
                     complement={complement}
                     getCEP={getCEP}
                 />
-                <AcceptanceTerm register={register} errors={errors}/>
+                <h1>Questão - Cidade</h1>
+                <RegionCity register={register} errors={errors} />
+
+                <h1>Questões - Beneficiários</h1>
+                <ResidentsQuantity register={register} errors={errors} />
+                <CurrentFinancialStatus register={register} errors={errors} />
+                <PreviousRegister register={register} errors={errors} />
+
+                <h1>Questões - Voluntários</h1>
+                <AvaiableDays register={register} errors={errors} />
+                <AvaiableHours register={register} errors={errors} />
+                <PreviousVolunteersRegister register={register} errors={errors} />
+                <WorkFront register={register} errors={errors} />
+                
+                <AcceptanceTerm register={register} errors={errors} />
             </form>
             
         </div>

--- a/vale-sem-fome/src/pages/TestNewComponents/index.js
+++ b/vale-sem-fome/src/pages/TestNewComponents/index.js
@@ -1,0 +1,121 @@
+import React, { useState } from 'react';
+import {
+    FullName,
+    Document,
+    Email,
+    BirthDay,
+    PhoneNumber,
+    HomeAddress,
+    AcceptanceTerm
+} from './../../components';
+import { useForm } from 'react-hook-form';
+import validarCpf from 'validar-cpf'
+import Api from '../../services/api'
+import Cep from '../../services/cep'
+
+
+function TestNewComponents(props) {
+    const { register, handleSubmit, errors } = useForm();
+    const [cep, setCep] = useState("");
+    const [street, setStreet] = useState("");
+    const [neighborhood, setNeighborhood] = useState("");
+    const [complement, setComplement] = useState("");
+    const [errorsMock, setErrosMock] = useState({ cep: false, street: false, neighborhood: false });
+    const onSubmit = async data => {
+        setErrosMock({
+            cep: (cep.length === 0) ? true : false,
+            street: (street.length === 0) ? true : false,
+            neighborhood: (neighborhood.length === 0) ? true : false
+        });
+        if (street.length === 0) {
+            alert('Digite sua rua!');
+        } else if (cep.length === 0) {
+            alert('Digite seu CEP!');
+        } else if (neighborhood.length === 0) {
+            alert('Digite seu bairro!')
+        } else if (validarCpf(data.document)) {
+            setErrosMock({ cep: false, street: false, neighborhood: false });
+            const newUser = {
+                cidadao_nome: data.fullName,
+                cidadao_email: data.email,
+                cidadao_celular: data.phone,
+                cidadao_cpf: data.document,
+                cidadao_endereco: street,
+                cidadao_endereco_cep: cep,
+                cidadao_endereco_complemento: complement,
+                cidadao_endereco_bairro: neighborhood,
+                cidadao_endereco_numero: data.number,
+                cidadao_endereco_referencia: data.referencePoint,
+                cidadao_endereco_pais: "Brasil",
+                cidadao_endereco_cidade: "São José dos Campos",
+                cidadao_endereco_estado: "São Paulo",
+                cidadao_tamanho_familia: data.residents,
+                cidadao_data_nascimento: data.birthday,
+                cidadao_area: data.region,
+                cidadao_situacao_risco: (data.situationMoment === "Outro") ? data.situationMomentOther : data.situationMoment,
+                cidadao_cadastro_unico: data.haveRegistry,
+                cidadao_termo_aceite: (data.termsAgreements === "Aceito") ? true : false
+            }
+
+            await Api.post('/create/beneficiario', newUser, {
+                headers: {
+                    'Access-Control-Allow-Origin': '*',
+                    'Access-Control-Allow-Methods': 'GET,HEAD,OPTIONS,POST,PUT',
+                    'Access-Control-Allow-Headers': 'origin, x-requested-with'
+                }
+            })
+                .then(response => {
+                    alert(response.data.message);
+                    props.history.push("/obrigado")
+                })
+                .catch(error => alert(error.response.data.message));
+        } else {
+            alert("CPF inválido!");
+        }
+    }
+
+    const getCEP = async (event) => {
+        const document = event.target.value.replace('-', '');
+        setCep(event.target.value);
+        if (document.length === 8) {
+            await Cep.get(`${document}/json`)
+                .then(response => {
+                    const { logradouro, bairro, complemento } = response.data;
+                    setStreet(logradouro);
+                    setNeighborhood(bairro);
+                    setComplement(complemento);
+                })
+                .catch(error => console.log(error));
+        }
+    }
+
+    return (
+        <div className="container">
+            <form onSubmit={handleSubmit(onSubmit)} className="form" id="form">
+                <FullName register={register} errors={errors}/>
+                <Document register={register} errors={errors}/>
+                <Email register={register} errors={errors}/>
+                <BirthDay register={register} errors={errors}/>
+                <PhoneNumber register={register} errors={errors}/>
+                <HomeAddress 
+                    register={register}
+                    errors={errors}
+                    errorsMock={errorsMock} 
+                    setComplement={setComplement}
+                    setErrosMock={setErrosMock}
+                    setStreet={setStreet}
+                    setNeighborhood={setNeighborhood}
+                    cep={cep}
+                    street={street}
+                    neighborhood={neighborhood}
+                    complement={complement}
+                    getCEP={getCEP}
+                />
+                <AcceptanceTerm register={register} errors={errors}/>
+            </form>
+            
+        </div>
+    )
+}
+
+export default TestNewComponents;

--- a/vale-sem-fome/src/pages/index.js
+++ b/vale-sem-fome/src/pages/index.js
@@ -3,3 +3,10 @@ export { default as Obrigado } from './Obrigado'
 export { default as Voluntarios } from './Voluntarios'
 export { default as ObrigadoVoluntario } from './Voluntario/Obrigado'
 export { default as PageNotFound } from './PageNotFound'
+
+
+/**
+ * Página de Teste
+ */
+
+export { default as TestNewComponents } from './TestNewComponents'

--- a/vale-sem-fome/src/routes.js
+++ b/vale-sem-fome/src/routes.js
@@ -3,11 +3,17 @@ import {
     Obrigado,
     Voluntarios,
     ObrigadoVoluntario,
-    PageNotFound
+    PageNotFound,
+    TestNewComponents
 } from './pages'
 
 export default {
     routes: [
+        {
+            name: 'TestNewComponents',
+            path: '/test',
+            component: TestNewComponents
+        },
         {
             name: 'Voluntarios',
             path: '/voluntarios',


### PR DESCRIPTION
I've separated the questions in two groups:
- `GeneralQuestions` - commom questions between forms.
- `SpecificQuestions` - different questions between forms.

Speaking about `SpecificQuestions`, we have:
- `Recipients` - people who will receive food.
- `Volunteers` - people who will work on this.

This is the current folders tree:

![Pasta de Components](https://user-images.githubusercontent.com/9155761/79032606-4744ac00-7b7e-11ea-8d1c-9d8f27b9508a.PNG)

Speaking about specific questions, I created this folders:

![Pastas de Perguntas Específicas](https://user-images.githubusercontent.com/9155761/79055831-74e53000-7c26-11ea-805c-22fc0cbe3273.PNG)

To test this components, I created the 'TestNewComponents' page:

![Pasta de Páginas](https://user-images.githubusercontent.com/9155761/79032657-9985cd00-7b7e-11ea-94ef-99261443501d.PNG)
